### PR TITLE
Trim trailing period from dictation

### DIFF
--- a/src/c/checklist.c
+++ b/src/c/checklist.c
@@ -122,7 +122,9 @@ void checklist_add_items(char *name) {
 }
 
 void add_item(char *name) {
-  name = capitalize(trim_whitespace(name));
+  name = trim_whitespace(name);
+  name = trim_trailing_period(name);
+  name = capitalize(name);
 
   if(s_checklist_length < MAX_CHECKLIST_ITEMS && strlen(name) > 0) {
     strncpy(s_checklist_items[s_checklist_length].name, name, MAX_NAME_LENGTH - 1);

--- a/src/c/util.c
+++ b/src/c/util.c
@@ -42,6 +42,19 @@ char* trim_whitespace(char *str) {
   return str;
 }
 
+char* trim_trailing_period(char *str) {
+  char *end;
+
+  end = str + strlen(str) - 1;
+
+  if (*end == '.') {
+    end--;
+    *(end+1) = 0;
+  }
+
+  return str;
+}
+
 /* find the next word starting at 's', delimited by characters
  * in the string 'delim', and store up to 'len' bytes into *buf
  * returns pointer to immediately after the word, or NULL if done.

--- a/src/c/util.h
+++ b/src/c/util.h
@@ -10,4 +10,5 @@ bool menu_layer_menu_index_selected(MenuLayer *menu_layer, MenuIndex *index);
 char is_space(char c);
 char *capitalize(char *str);
 char *trim_whitespace(char *str);
+char *trim_trailing_period(char *str);
 char *strwrd(char *s, char *buf, size_t len, char *delim);


### PR DESCRIPTION
Dictation can produce checklist items with a trailing period. Example:

- Eggs.
- Bread.
- Milk.

This change trims any trailing period from the checklist item _after_ whitespace has been trimmed and _before_ capitalizing the string:

- Eggs
- Bread
- Milk